### PR TITLE
Added tests for set extraction configuration

### DIFF
--- a/Sets Library/SetsLibrary.Tests/Models/SetExtractionConfigurationTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Models/SetExtractionConfigurationTests.cs
@@ -1,0 +1,141 @@
+﻿using Xunit;
+using SetsLibrary.Models;
+using SetLibrary.Models;
+namespace SetsLibrary.Tests.Models
+{
+    public class SetExtractionConfigurationTests
+    {
+        [Fact]
+        public void Constructor_Should_Throw_ArgumentNullException_When_FieldTerminator_Is_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SetExtractionConfiguration<int>(null, ""));
+        }//Constructor_Should_Throw_ArgumentNullException_When_FieldTerminator_Is_Null
+
+        [Fact]
+        public void Constructor_Should_Throw_ArgumentNullException_When_RowTerminator_Is_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SetExtractionConfiguration<int>(",",null));
+        }//Constructor_Should_Throw_ArgumentNullException_When_FieldTerminator_Is_Null
+
+
+        [Fact]
+        public void Constructor_Should_Throw_ArgumentException_When_Terminators_Are_The_Same()
+        {
+            string terminator = ";";
+
+            Assert.Throws<ArgumentException>(() => new SetExtractionConfiguration<int>(terminator, terminator));
+        }//Constructor_Should_Throw_ArgumentNullException_When_FieldTerminator_Is_Null
+
+
+        [Theory]
+        [InlineData(";", ",}")]
+        [InlineData("{;}", "\"\"")]
+        [InlineData("}{", ",'}")]
+        [InlineData(" \\{", "','")]
+        [InlineData("}", ";;")]
+        [InlineData("5434sfsdf}", "sdfsdfsf")]
+        public void Constructor_Should_Throw_ArgumentException_When_Terminators_Use_Reserved_Characters(string fieldTerm, string rownTerm)
+        {
+            Assert.Throws<ArgumentException>(() => new SetExtractionConfiguration<int>(fieldTerm, rownTerm));
+        }//Constructor_Should_Throw_ArgumentNullException_When_FieldTerminator_Is_Null
+
+        [Theory]
+        [InlineData(";", "'")]
+        [InlineData("-", "\"\"")]
+        [InlineData("=", ",'")]
+        [InlineData("+", "-")]
+        [InlineData("''", ";;")]
+        [InlineData("5434sfsdf", "sdfsdfs")]
+        public void Valid_Terminators(string fieldTerminator, string rowTerminator)
+        {
+            //Create a null instance
+            SetExtractionConfiguration<int>? config = null;
+
+            try
+            {
+                config = new SetExtractionConfiguration<int>(fieldTerminator, rowTerminator);
+            }
+            catch { }//Swallow the exeption
+
+            //Check if the 'config variable is not null
+            Assert.NotNull(config);
+            
+            //Verify the terminators
+            Assert.Equal(fieldTerminator, config.FieldTerminator);
+            Assert.Equal(rowTerminator, config.RowTerminator);
+        }//Constructor_Should_Throw_ArgumentNullException_When_FieldTerminator_Is_Null
+
+        [Theory]
+        [InlineData(null, "rowTerminator")]
+        [InlineData("fieldTerminator", null)]
+        public void Constructor_NullTerminators_ThrowsArgumentNullException(string fieldTerminator, string rowTerminator)
+        {
+            Assert.Throws<ArgumentNullException>(() => new SetExtractionConfiguration<string>(fieldTerminator, rowTerminator));
+        }
+
+        [Fact]
+        public void Constructor_SameFieldAndRowTerminators_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new SetExtractionConfiguration<string>("terminator", "terminator"));
+        }
+
+        [Theory]
+        [InlineData("{", "rowTerminator")]
+        [InlineData("fieldTerminator", "}")]
+        public void Constructor_ReservedCharactersInTerminators_ThrowsArgumentException(string fieldTerminator, string rowTerminator)
+        {
+            Assert.Throws<ArgumentException>(() => new SetExtractionConfiguration<string>(fieldTerminator, rowTerminator));
+        }
+
+        [Fact]
+        public void Constructor_ValidTerminators_AssignsTerminators()
+        {
+            var config = new SetExtractionConfiguration<string>("fieldTerminator", "rowTerminator");
+            Assert.Equal("fieldTerminator", config.FieldTerminator);
+            Assert.Equal("rowTerminator", config.RowTerminator);
+            Assert.False(config.IsICustomObject);
+        }
+
+        [Fact]
+        public void Constructor_NullConverter_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SetExtractionConfiguration<string>("fieldTerminator", "rowTerminator", null));
+        }
+
+        [Fact]
+        public void Constructor_ValidConverter_AssignsConverter()
+        {
+            var converter = new MockConverter();
+            var config = new SetExtractionConfiguration<string>("fieldTerminator", "rowTerminator", converter);
+            Assert.Equal("fieldTerminator", config.FieldTerminator);
+            Assert.Equal("rowTerminator", config.RowTerminator);
+            Assert.True(config.IsICustomObject);
+            Assert.Equal(converter, config.Converter);
+        }
+
+        [Fact]
+        public void ToObject_NullConverter_ThrowsArgumentNullException()
+        {
+            var config = new SetExtractionConfiguration<string>("fieldTerminator", "rowTerminator");
+            Assert.Throws<ArgumentNullException>(() => config.ToObject("record"));
+        }
+
+        [Fact]
+        public void ToObject_ValidConverter_CallsConverter()
+        {
+            var converter = new MockConverter();
+            var config = new SetExtractionConfiguration<string>("fieldTerminator", "rowTerminator", converter);
+            var result = config.ToObject("record");
+            Assert.Equal("convertedRecord", result);
+        }
+
+        private class MockConverter : ICustomObjectConverter<string>
+        {
+            public string ToObject(string field, SetExtractionConfiguration<string> settings)
+            {
+                return "convertedRecord";
+            }
+        }
+
+    }//class
+}//namespace


### PR DESCRIPTION
### Summary
This commit introduces a comprehensive suite of xUnit tests for the `SetExtractionConfiguration` class, ensuring its robustness and correctness across various scenarios. The tests validate the class's behavior with different terminator configurations and custom object converters.

### Changes
- **Unit Tests for Constructor:**
  - **Null Terminators:** Added tests to verify that the constructor throws `ArgumentNullException` when either the field or row terminator is null.
  - **Same Terminators:** Added tests to ensure that the constructor throws `ArgumentException` when the field and row terminators are the same.
  - **Reserved Characters:** Added tests to check that the constructor throws `ArgumentException` if the terminators contain any reserved characters (`{` or `}`).

- **Valid Terminators:**
  - Added tests to verify that valid terminators are correctly assigned and that the `IsICustomObject` flag is set to `false`.

- **Custom Object Converter:**
  - Added tests to ensure that the constructor throws `ArgumentNullException` if a null converter is passed.
  - Verified that a valid converter is correctly assigned, the `IsICustomObject` flag is set to `true`, and the `Converter` property is properly initialized.

- **ToObject Method:**
  - Added tests to ensure that the `ToObject` method throws `ArgumentNullException` if the `Converter` is null.
  - Verified that the `ToObject` method correctly calls the converter and returns the expected object when a valid converter is provided.

### Test Coverage
- **Constructor Validations:** Ensures that the class correctly handles edge cases such as null values, identical terminators, and reserved characters.
- **Valid Terminators Assignment:** Verifies that valid terminators are assigned correctly and that the `IsICustomObject` flag is managed appropriately.
- **Custom Object Conversion:** Ensures that the custom object conversion process is robust, validating both the assignment of the converter and the execution of the `ToObject` method.

### Additional Notes
- **Mocking:** Utilized a mock converter class (`MockConverter`) to facilitate testing of the `ToObject` method and verify that the conversion logic is correctly executed.