### PR TITLE
Refactor BaseSet to Inject SetTreeWrapper

### DIFF
--- a/Sets Library/Sets Library/Models/Sets/CustomObjectSet.cs
+++ b/Sets Library/Sets Library/Models/Sets/CustomObjectSet.cs
@@ -46,7 +46,14 @@ internal class CustomObjectSet<T> : BaseSet<T>
         : base(expression, config)
     {
     }
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomObjectSet{T}"/> class by injecting an existing instance of IIndexedSetTree.
+    /// This constructor allows for complete control over the set tree, including the expression and extraction settings.
+    /// </summary>
+    /// <param name="indexedSetTree">An existing instance of an IIndexedSetTree that provides both the set elements 
+    /// and configuration for extraction.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="indexedSetTree"/> is null.</exception>
+    public CustomObjectSet(IIndexedSetTree<T> indexedSetTree): base(indexedSetTree) { }
     #endregion Constructors
 
     #region Overrides

--- a/Sets Library/Sets Library/Models/Sets/StringLiteralSet.cs
+++ b/Sets Library/Sets Library/Models/Sets/StringLiteralSet.cs
@@ -19,7 +19,9 @@
 using SetsLibrary;
 
 namespace SetsLibrary;
-
+/// <summary>
+/// Represents a string literal set that can contain any string elements.
+/// </summary>
 public class StringLiteralSet : BaseSet<string>
 {
     #region Constructors
@@ -40,7 +42,14 @@ public class StringLiteralSet : BaseSet<string>
     public StringLiteralSet(string expression, SetExtractionConfiguration<string> config) : base(expression, config)
     {
     }
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StringLiteralSet"/> class by injecting an existing instance of IIndexedSetTree.
+    /// This constructor allows for complete control over the set tree, including the expression and extraction settings.
+    /// </summary>
+    /// <param name="indexedSetTree">An existing instance of an IIndexedSetTree that provides both the set elements 
+    /// and configuration for extraction.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="indexedSetTree"/> is null.</exception>
+    public StringLiteralSet(IIndexedSetTree<string> indexedSetTree) : base(indexedSetTree) { }
     #endregion Constructors
 
     #region Overrides

--- a/Sets Library/Sets Library/Models/Sets/TypedSet.cs
+++ b/Sets Library/Sets Library/Models/Sets/TypedSet.cs
@@ -43,7 +43,14 @@ public class TypedSet<T> : BaseSet<T>
     public TypedSet(string expression, SetExtractionConfiguration<T> config) : base(expression, config)
     {
     }
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TypedSet{T}"/> class by injecting an existing instance of IIndexedSetTree.
+    /// This constructor allows for complete control over the set tree, including the expression and extraction settings.
+    /// </summary>
+    /// <param name="indexedSetTree">An existing instance of an IIndexedSetTree that provides both the set elements 
+    /// and configuration for extraction.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="indexedSetTree"/> is null.</exception>
+    public TypedSet(IIndexedSetTree<T> indexedSetTree) : base(indexedSetTree) { }
     #endregion Constructors
 
     #region Overrides

--- a/Sets Library/Sets Library/Models/Wrapper/SetTreeBaseWrapper.cs
+++ b/Sets Library/Sets Library/Models/Wrapper/SetTreeBaseWrapper.cs
@@ -42,6 +42,11 @@ public abstract class SetTreeBaseWrapper<T> : IIndexedSetTree<T>
         ArgumentNullException.ThrowIfNull(setTree, nameof(setTree));
         this.setTree = setTree;
     }
+    internal SetTreeBaseWrapper(SetExtractionConfiguration<T> config)
+    {
+        //Creates a new instance of the set tree
+        setTree = new SetTree<T>(config);
+    }//ctor default
 
     /// <summary>
     /// Gets the root elements of the set as a string.

--- a/Sets Library/Sets Library/Models/Wrapper/SetTreeWrapper.cs
+++ b/Sets Library/Sets Library/Models/Wrapper/SetTreeWrapper.cs
@@ -36,7 +36,7 @@ public class SetTreeWrapper<T> : SetTreeBaseWrapper<T>
         if (setTree is SetTree<T>) // if they are the same, cast the setTree structure
             _assSetTree = setTree as SetTree<T>;
     }
-
+    internal SetTreeWrapper(SetExtractionConfiguration<T> config) : base(config) { }
     /// <summary>
     /// Gets the root element at the specified index.
     /// </summary>


### PR DESCRIPTION
## Pull Request: Refactor BaseSet to Inject SetTreeWrapper

This refactor modifies the `BaseSet` class to accept an injected `SetTreeWrapper<T>` rather than creating it internally. The change introduces a new constructor that allows for injecting an already initialized `IIndexedSetTree<T>`. The previous constructors are maintained but now rely on the injected tree or configuration. This approach improves flexibility and testing, as the `SetTreeWrapper` can now be provided from external sources instead of being tightly coupled with `BaseSet`.

Additionally, proper exception handling has been added to ensure that null or invalid arguments are caught, and relevant exceptions are thrown for better error handling and code robustness.
