### PR TITLE
Fix: Update subset removal logic to prevent issues with nested elements

### DIFF
--- a/Sets Library/Sets Library/Utility/SetTreeExtractor.cs
+++ b/Sets Library/Sets Library/Utility/SetTreeExtractor.cs
@@ -79,7 +79,7 @@ public class SetTreeExtractor<T>
                 string subset = expression.Substring(start, length);
 
                 // Remove the subset from the original expression to prevent duplicates
-                expression = expression.Replace(subset, "");
+                expression = expression.Remove(start, length);
                 i = start; // Reset the index to continue from the correct position
 
                 // Clear the braces management stacks and add the subset


### PR DESCRIPTION
**Branch:** `fix/set-extraction-utility`

**Description:**

This pull request addresses an issue in the `SetTreeExtractor` class where the expression was being modified incorrectly by replacing nested subsets with an empty string. The original method used `expression.Replace(subset, "")`, which could lead to malformed expressions when dealing with nested elements.

### Changes made:
- Replaced the incorrect `expression.Replace(subset, "")` with `expression.Remove(start, length)` to properly remove subsets without disturbing the expression.
- This update ensures that nested subsets are handled correctly, avoiding potential issues with malformed or incomplete expressions.

### Code Changes:
- In the `Extract` method, the line:
  ```
  expression = expression.Replace(subset, "");
  ```
  has been replaced with:
  ```
  expression = expression.Remove(start, length);
  ```

This change ensures that the expression is properly updated when subsets are removed, and prevents issues with nested sets where `Replace` could have caused unwanted behavior.
