### PR TITLE
Refactor/set tree adding element

### DIFF
--- a/Sets Library/Sets Library/Interfaces/ISetTree.cs
+++ b/Sets Library/Sets Library/Interfaces/ISetTree.cs
@@ -72,7 +72,7 @@ public interface ISetTree<T> : IComparable<ISetTree<T>>
     /// <returns>
     /// An enumerator that can be used to iterate through the subsets of the current set.
     /// </returns>
-    IEnumerable<ISetTree<T>> GetSubsetsEnumarator();
+    IEnumerable<ISetTree<T>> GetSubsetsEnumerator();
 
     /// <summary>
     /// Returns an enumerator that iterates through the root elements of the current set.
@@ -80,7 +80,7 @@ public interface ISetTree<T> : IComparable<ISetTree<T>>
     /// <returns>
     /// An enumerator that can be used to iterate through the root elements of the current set.
     /// </returns>
-    IEnumerable<T> GetRootElementsEnumarator();
+    IEnumerable<T> GetRootElementsEnumerator();
 
     /// <summary>
     /// Adds a subset inside the current set.

--- a/Sets Library/Sets Library/Models/SetTree/SetTree.cs
+++ b/Sets Library/Sets Library/Models/SetTree/SetTree.cs
@@ -10,7 +10,13 @@ namespace SetsLibrary;
 public class SetTree<T> : ISetTree<T> where T : IComparable<T>
 {
     #region Data-fields
+    /// <summary>
+    /// Collection of root elements.
+    /// </summary>
     protected internal readonly ISortedElements<T> _elements;
+    /// <summary>
+    /// Collection of subsets in the root of the tree.
+    /// </summary>
     protected internal readonly ISortedSubSets<T> _subSets;
     #endregion Data-fields
 
@@ -119,11 +125,8 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
         //Check for nulls
         ArgumentNullException.ThrowIfNull(element, nameof(element));
 
-        //Check if element exists
-        int index = _elements.IndexOf(element);
-
-        if (index == -1)//Element does not exist
-            _elements.Add(element);
+        //Add element if it is unique
+        _elements.AddIfUnique(element);
     }
 
     /// <summary>
@@ -149,11 +152,8 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
         //Check for nulls
         ArgumentNullException.ThrowIfNull(tree, nameof(tree));
 
-        //Check if element exists
-        int index = _subSets.IndexOf(tree);
-
-        if (index == -1)//Tree does not exist
-            this._subSets.Add(tree);
+        //Add if unique
+        _subSets.AddIfUnique(tree);
     }
 
     /// <summary>
@@ -293,7 +293,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
             if (comparer != 0)
                 return comparer;
 
-            //increament the index
+            //increment the index
             elementIndex++;
         }
 
@@ -309,7 +309,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
             if (comparer != 0)
                 return comparer;
 
-            //increament the index
+            //increment the index
             elementIndex++;
         }
 

--- a/Sets Library/Sets Library/Models/SetTree/SetTree.cs
+++ b/Sets Library/Sets Library/Models/SetTree/SetTree.cs
@@ -284,7 +284,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
         int elementIndex = 0;
         //Here they have the same number of root elements and subsets
         //-Enumerate through all the root elements of other and compare them with the elements of this
-        foreach (T element in other.GetRootElementsEnumarator())
+        foreach (T element in other.GetRootElementsEnumerator())
         {
             //Compare correspond elements
             int comparer = this._elements[elementIndex].CompareTo(element);
@@ -300,7 +300,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
         elementIndex = 0;
         //Here it means that the root elements are the same
         //-We need to check each subset
-        foreach (ISetTree<T> tree in other.GetSubsetsEnumarator())
+        foreach (ISetTree<T> tree in other.GetSubsetsEnumerator())
         {
             //Do it recursively
             int comparer = this._subSets[elementIndex].CompareTo(tree);
@@ -330,7 +330,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
     /// Gets an enumerator for the root elements of the set tree.
     /// </summary>
     /// <returns>An enumerator for the root elements.</returns>
-    public IEnumerable<T> GetRootElementsEnumarator()
+    public IEnumerable<T> GetRootElementsEnumerator()
     {
         return this._elements;
     }
@@ -339,7 +339,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
     /// Gets an enumerator for the subset trees of the set tree.
     /// </summary>
     /// <returns>An enumerator for the subset trees.</returns>
-    public IEnumerable<ISetTree<T>> GetSubsetsEnumarator()
+    public IEnumerable<ISetTree<T>> GetSubsetsEnumerator()
     {
         return this._subSets;
     }

--- a/Sets Library/Sets Library/Models/Sets/BaseSet.cs
+++ b/Sets Library/Sets Library/Models/Sets/BaseSet.cs
@@ -442,7 +442,7 @@ public abstract class BaseSet<T> : IStructuredSet<T>
     /// <returns>An enumerable collection of root elements in the set.</returns>
     public IEnumerable<T> EnumerateRootElements()
     {
-        return _treeWrapper.GetRootElementsEnumarator();
+        return _treeWrapper.GetRootElementsEnumerator();
     }//EnumerateRootElements
 
     /// <summary>
@@ -451,7 +451,7 @@ public abstract class BaseSet<T> : IStructuredSet<T>
     /// <returns>An enumerable collection of subsets in the set.</returns>
     public IEnumerable<IStructuredSet<T>> EnumerateSubsets()
     {
-        foreach (var item in _treeWrapper.GetSubsetsEnumarator())
+        foreach (var item in _treeWrapper.GetSubsetsEnumerator())
         {
             yield return BuildNewSet(new SetTreeWrapper<T>(item));
         }

--- a/Sets Library/Sets Library/Models/Wrapper/SetTreeBaseWrapper.cs
+++ b/Sets Library/Sets Library/Models/Wrapper/SetTreeBaseWrapper.cs
@@ -123,18 +123,18 @@ public abstract class SetTreeBaseWrapper<T> : IIndexedSetTree<T>
     /// Gets an enumerator for the root elements in the set.
     /// </summary>
     /// <returns>An enumerator for the root elements.</returns>
-    public IEnumerable<T> GetRootElementsEnumarator()
+    public IEnumerable<T> GetRootElementsEnumerator()
     {
-        return setTree.GetRootElementsEnumarator();
+        return setTree.GetRootElementsEnumerator();
     }
 
     /// <summary>
     /// Gets an enumerator for the subsets in the set.
     /// </summary>
     /// <returns>An enumerator for the subsets.</returns>
-    public IEnumerable<ISetTree<T>> GetSubsetsEnumarator()
+    public IEnumerable<ISetTree<T>> GetSubsetsEnumerator()
     {
-        return setTree.GetSubsetsEnumarator();
+        return setTree.GetSubsetsEnumerator();
     }
 
     /// <summary>

--- a/Sets Library/Sets Library/Models/Wrapper/SetTreeWrapper.cs
+++ b/Sets Library/Sets Library/Models/Wrapper/SetTreeWrapper.cs
@@ -52,7 +52,7 @@ public class SetTreeWrapper<T> : SetTreeBaseWrapper<T>
 
         // Else, do a loop
         int currentIndex = 0;
-        foreach (T item in base.GetRootElementsEnumarator())
+        foreach (T item in base.GetRootElementsEnumerator())
         {
             if (currentIndex == index)
                 return item;
@@ -75,7 +75,7 @@ public class SetTreeWrapper<T> : SetTreeBaseWrapper<T>
 
         // Else, do a loop
         int currentIndex = 0;
-        foreach (ISetTree<T> item in base.GetSubsetsEnumarator())
+        foreach (ISetTree<T> item in base.GetSubsetsEnumerator())
         {
             if (currentIndex == index)
                 return item;

--- a/Sets Library/Sets Library/Utility/SetTreeUtility.cs
+++ b/Sets Library/Sets Library/Utility/SetTreeUtility.cs
@@ -63,7 +63,7 @@ public static class SetTreeUtility<T>
         string elementTree = "";
 
         // Loop through all subsets of the current tree
-        foreach (ISetTree<T> subtree in currentTree.GetSubsetsEnumarator().ToList())
+        foreach (ISetTree<T> subtree in currentTree.GetSubsetsEnumerator().ToList())
         {
             // Recursively retrieve the string representation of the subtree
             string sub = BuildTree(subtree);

--- a/Sets Library/SetsLibrary.Tests/Models/SetTree/SetTreeTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Models/SetTree/SetTreeTests.cs
@@ -13,8 +13,8 @@ namespace SetsLibrary.Tests.Models.SetTree
             var extractionSettings = new SetExtractionConfiguration<int>(";", ",");
             var setTree = new SetTree<int>(extractionSettings);
             Assert.NotNull(setTree);
-            Assert.Empty(setTree.GetRootElementsEnumarator());
-            Assert.Empty(setTree.GetSubsetsEnumarator());
+            Assert.Empty(setTree.GetRootElementsEnumerator());
+            Assert.Empty(setTree.GetSubsetsEnumerator());
             Assert.Equal(0, setTree.Count);
         }
 
@@ -34,9 +34,9 @@ namespace SetsLibrary.Tests.Models.SetTree
             var elements = new List<int> { 1, 2, 3 };
             var setTree = new SetTree<int>(extractionSettings, elements);
             Assert.Equal(3, setTree.CountRootElements);
-            Assert.Contains(1, setTree.GetRootElementsEnumarator());
-            Assert.Contains(2, setTree.GetRootElementsEnumarator());
-            Assert.Contains(3, setTree.GetRootElementsEnumarator());
+            Assert.Contains(1, setTree.GetRootElementsEnumerator());
+            Assert.Contains(2, setTree.GetRootElementsEnumerator());
+            Assert.Contains(3, setTree.GetRootElementsEnumerator());
         }
 
         #endregion Constructor Tests
@@ -49,7 +49,7 @@ namespace SetsLibrary.Tests.Models.SetTree
             var extractionSettings = new SetExtractionConfiguration<int>(";", ",");
             var setTree = new SetTree<int>(extractionSettings);
             setTree.AddElement(10);
-            Assert.Contains(10, setTree.GetRootElementsEnumarator());
+            Assert.Contains(10, setTree.GetRootElementsEnumerator());
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace SetsLibrary.Tests.Models.SetTree
             var setTree = new SetTree<int>(extractionSettings);
             setTree.AddElement(10);
             setTree.AddElement(10); // Adding again
-            Assert.Single(setTree.GetRootElementsEnumarator()); // Only one occurrence of 10
+            Assert.Single(setTree.GetRootElementsEnumerator()); // Only one occurrence of 10
         }
 
         [Fact]
@@ -81,9 +81,9 @@ namespace SetsLibrary.Tests.Models.SetTree
             var setTree = new SetTree<int>(extractionSettings);
             setTree.AddRange(new List<int> { 1, 2, 3 });
             Assert.Equal(3, setTree.CountRootElements);
-            Assert.Contains(1, setTree.GetRootElementsEnumarator());
-            Assert.Contains(2, setTree.GetRootElementsEnumarator());
-            Assert.Contains(3, setTree.GetRootElementsEnumarator());
+            Assert.Contains(1, setTree.GetRootElementsEnumerator());
+            Assert.Contains(2, setTree.GetRootElementsEnumerator());
+            Assert.Contains(3, setTree.GetRootElementsEnumerator());
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace SetsLibrary.Tests.Models.SetTree
 
             setTree.AddSubSetTree(subsetTree);
 
-            Assert.Single(setTree.GetSubsetsEnumarator());
+            Assert.Single(setTree.GetSubsetsEnumerator());
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace SetsLibrary.Tests.Models.SetTree
             setTree.AddElement(10);
             bool result = setTree.RemoveElement(10);
             Assert.True(result);
-            Assert.DoesNotContain(10, setTree.GetRootElementsEnumarator());
+            Assert.DoesNotContain(10, setTree.GetRootElementsEnumerator());
         }
 
         [Fact]
@@ -166,7 +166,7 @@ namespace SetsLibrary.Tests.Models.SetTree
 
             bool result = setTree.RemoveElement(subsetTree);
             Assert.True(result);
-            Assert.Empty(setTree.GetSubsetsEnumarator());
+            Assert.Empty(setTree.GetSubsetsEnumerator());
         }
 
         [Fact]
@@ -264,7 +264,7 @@ namespace SetsLibrary.Tests.Models.SetTree
             var setTree = new SetTree<int>(extractionSettings);
             setTree.AddElement(1);
             setTree.AddElement(2);
-            var rootElements = setTree.GetRootElementsEnumarator();
+            var rootElements = setTree.GetRootElementsEnumerator();
             Assert.Contains(1, rootElements);
             Assert.Contains(2, rootElements);
         }
@@ -277,7 +277,7 @@ namespace SetsLibrary.Tests.Models.SetTree
             var subsetTree = new SetTree<int>(extractionSettings);
             subsetTree.AddElement(5);
             setTree.AddSubSetTree(subsetTree);
-            var subsets = setTree.GetSubsetsEnumarator();
+            var subsets = setTree.GetSubsetsEnumerator();
             Assert.Contains(subsetTree, subsets);
         }
         #endregion Root Elements and Subsets Enumerator Tests
@@ -292,7 +292,7 @@ namespace SetsLibrary.Tests.Models.SetTree
             setTree.AddElement(5);
             setTree.AddElement(5); //Adding duplicate element
 
-            Assert.Single(setTree.GetRootElementsEnumarator()); //Should only contain 5 once
+            Assert.Single(setTree.GetRootElementsEnumerator()); //Should only contain 5 once
         }
 
         [Fact]
@@ -403,7 +403,7 @@ namespace SetsLibrary.Tests.Models.SetTree
 
             bool result = setTree.RemoveElement(10); // Removing an element from the root set
             Assert.True(result); // Should remove 10 successfully
-            Assert.DoesNotContain(10, setTree.GetRootElementsEnumarator());
+            Assert.DoesNotContain(10, setTree.GetRootElementsEnumerator());
         }
 
         [Fact]
@@ -521,7 +521,7 @@ namespace SetsLibrary.Tests.Models.SetTree
             // Remove an element
             bool removed = setTree.RemoveElement(2);
             Assert.True(removed);
-            Assert.False(setTree.GetRootElementsEnumarator().Contains(2)); // Should not contain 2 anymore
+            Assert.False(setTree.GetRootElementsEnumerator().Contains(2)); // Should not contain 2 anymore
 
             // Try removing an element that doesn't exist
             removed = setTree.RemoveElement(10);

--- a/Sets Library/SetsLibrary.Tests/Utilities/SetTreeExtractor_ExtractTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Utilities/SetTreeExtractor_ExtractTests.cs
@@ -41,8 +41,8 @@ namespace SetsLibrary.Tests.Utilities.Extract
                 Count += elements is ICollection<T> collection ? collection.Count : 0;
             }
 
-            public IEnumerable<ISetTree<T>> GetSubsetsEnumarator() => _subsets;
-            public IEnumerable<T> GetRootElementsEnumarator() => _elements;
+            public IEnumerable<ISetTree<T>> GetSubsetsEnumerator() => _subsets;
+            public IEnumerable<T> GetRootElementsEnumerator() => _elements;
             public bool RemoveElement(T element) => _elements.Remove(element);
             public bool RemoveElement(ISetTree<T> element) => _subsets.Remove(element);
             public int IndexOf(T element) => _elements.IndexOf(element);
@@ -117,7 +117,7 @@ namespace SetsLibrary.Tests.Utilities.Extract
             Assert.Equal(1, tree.CountSubsets);
 
             // Assert for the first subset
-            ISetTree<int> subsetTree = tree.GetSubsetsEnumarator().First();
+            ISetTree<int> subsetTree = tree.GetSubsetsEnumerator().First();
             Assert.Equal("3,4", subsetTree.RootElements);
             Assert.Equal(2, subsetTree.Count);
             Assert.Equal(2, subsetTree.CountRootElements);
@@ -142,12 +142,12 @@ namespace SetsLibrary.Tests.Utilities.Extract
             Assert.Equal(2, tree.CountSubsets);
 
             // Assert for the first subset
-            ISetTree<int> subsetTree1 = tree.GetSubsetsEnumarator().ElementAt(0);
+            ISetTree<int> subsetTree1 = tree.GetSubsetsEnumerator().ElementAt(0);
             Assert.Equal("3,4", subsetTree1.RootElements);
             Assert.Equal(2, subsetTree1.Count);
 
             // Assert for the second subset
-            ISetTree<int> subsetTree2 = tree.GetSubsetsEnumarator().ElementAt(1);
+            ISetTree<int> subsetTree2 = tree.GetSubsetsEnumerator().ElementAt(1);
             Assert.Equal("5,6", subsetTree2.RootElements);
             Assert.Equal(2, subsetTree2.Count);
         }


### PR DESCRIPTION
# Pull Request: Update Add Method to Ensure Uniqueness and Fix Documentation

- Replaced the old element addition logic in the class with a new approach using `AddIfUnique` to ensure uniqueness when adding elements to the collection.
- Updated the XML documentation to fix spelling errors and improve clarity in method names.

## Changes:
- Replaced the `IndexOf` check and `Add` with `_elements.AddIfUnique(element)` to handle unique element addition.
- Fixed spelling mistakes in XML doc comments.
