### PR TITLE
Generate next key after ching nulls

### DIFF
--- a/Sets Library/Sets Library/Collections/Sets collections/SetCollection.cs
+++ b/Sets Library/Sets Library/Collections/Sets collections/SetCollection.cs
@@ -95,10 +95,11 @@ public class SetCollection<T> : ISetCollection<IStructuredSet<T>, T>
     /// <param name="item">The set to add.</param>
     public void Add(IStructuredSet<T> item)
     {
-        string key = GenerateNextKey();
-
         // Check for nulls
         ArgumentNullException.ThrowIfNull(item, nameof(item));
+
+        //Generate the next key
+        string key = GenerateNextKey();
 
         // Add the element
         _dicCollection.Add(key, item);


### PR DESCRIPTION
### Pull Request: Fix Key Generation Order in `Add` Method

#### Summary:
In the `Add` method of the `SetCollection<T>` class, the key is generated before checking if `item` is `null`. This PR reorders the logic so the key is only generated after the null check.

#### Changes:
- Moved the null check before generating the key in the `Add` method.

#### Suggested Change:
```csharp
namespace SetsLibrary.Collections
{
    public class SetCollection<T> : ISetCollection<IStructuredSet<T>, T>
        where T : IComparable<T>
    {
        public void Add(IStructuredSet<T> item)
        {
            // Check for nulls before generating the key
            ArgumentNullException.ThrowIfNull(item, nameof(item));

            // Generate the next key after the null check
            string key = GenerateNextKey();

            // Add the element
            _dicCollection.Add(key, item);
        }
    }
}
```

### Comment:
The key should only be generated after confirming that `item` is not `null`, to avoid unnecessary operations when the input is invalid.
