### PR TITLE
Fix/set tree representation

### DIFF
--- a/Sets Library/Sets Library/Models/SetTree/SetTree.cs
+++ b/Sets Library/Sets Library/Models/SetTree/SetTree.cs
@@ -179,11 +179,13 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
         ArgumentNullException.ThrowIfNull(tree, nameof(tree));
 
         //First check if it is a null set or not
-        if(tree.TreeInfo.IsEmptyTree)
+        if (tree.TreeInfo.IsEmptyTree)
         {
             //Add it as a null set
             WillHaveNullElements(true, 1);
         }
+        //Update the current's tree info
+        TreeInfo.IsEmptyTree = false;
 
         //Add if unique
         _subSets.AddIfUnique(tree);

--- a/Sets Library/Sets Library/Utility/SetTreeUtility.cs
+++ b/Sets Library/Sets Library/Utility/SetTreeUtility.cs
@@ -48,20 +48,13 @@ public static class SetTreeUtility<T>
     /// <returns>A string representing the set tree, where subsets are enclosed in curly braces and empty sets are represented as ∅.</returns>
     private static string BuildTree(ISetTree<T> currentTree)
     {
-        string representation = "{";
-        //Get the root elements
-        var root = currentTree.RootElements;
+        if(currentTree.TreeInfo.IsEmptyTree)
+        {
+            return "{}";//Return nothing (Ø)
+        }
 
-        if(currentTree.CountSubsets == 0 && string.IsNullOrEmpty(root))
-        {
-            //This is an empty set
-            representation += "\u2205";
-        }
-        else
-        {
-            //Attach the root elements
-            representation += root;
-        }
+        //Here the tree is none empty(it has something in it)
+        string representation = "{" + currentTree.RootElements; 
 
         //Loop through the subsets
         foreach (var subset in currentTree.GetSubsetsEnumerator())

--- a/Sets Library/SetsLibrary.Tests/Models/Sets/BaseSetWithTypedSetTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Models/Sets/BaseSetWithTypedSetTests.cs
@@ -114,7 +114,7 @@ namespace SetsLibrary.Tests.Models.Sets
             var baseSet = new TypedSet<int>(expression, _extractionConfig);
 
             baseSet.Clear();
-            Assert.Equal("{\u2205}", baseSet.BuildStringRepresentation()); // Should be empty set
+            Assert.Equal("{}", baseSet.BuildStringRepresentation()); // Should be empty set
             Assert.Equal(0, baseSet.Cardinality); // Cardinality should be 0 after clearing
         }
 

--- a/Sets Library/SetsLibrary.Tests/Models/Sets/CustomObjectTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Models/Sets/CustomObjectTests.cs
@@ -111,7 +111,7 @@ namespace SetsLibrary.Tests.Models.Sets
             var result = set.BuildStringRepresentation();
 
             // Assert
-            var expected = "{∅}";
+            var expected = "{}";
             Assert.Equal(expected, result);
         }
 
@@ -297,7 +297,7 @@ namespace SetsLibrary.Tests.Models.Sets
             var result = set.BuildStringRepresentation();
 
             // Assert
-            Assert.Equal("{John, Doe,20\n{∅}}", result); // Empty nested set should be ignored
+            Assert.Equal("{John, Doe,20\n{}}", result); // Empty nested set should be ignored
         }
 
         // Test: Multiple Custom Object Converters (Different Field Terminators)

--- a/Sets Library/SetsLibrary.Tests/Models/Sets/StringLiteralTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Models/Sets/StringLiteralTests.cs
@@ -40,7 +40,7 @@ namespace SetsLibrary.Tests.Models.Sets
             var stringSet = new StringLiteralSet(_extractionConfig);
 
             Assert.IsType<StringLiteralSet>(stringSet);
-            Assert.Equal("{\u2205}", stringSet.BuildStringRepresentation());  // Assumes the default set string is empty
+            Assert.Equal("{}", stringSet.BuildStringRepresentation());  // Assumes the default set string is empty
         }
 
         // Test for the GetString method
@@ -111,7 +111,7 @@ namespace SetsLibrary.Tests.Models.Sets
 
             var result = stringSet.BuildStringRepresentation();
             stringSet.AddElement("2");
-            Assert.Equal("{\u2205}", result);  // Assuming empty set results in an empty string representation
+            Assert.Equal("{}", result);  // Assuming empty set results in an empty string representation
             Assert.Equal("{2}", stringSet.BuildStringRepresentation());
         }
     }


### PR DESCRIPTION
## Describe your changes
Updated SetTee utility for converting a SetTree to a string by replacing the empty set 'Ø' with '{}'. This approach ensures that even when a new set is created from a string representaion of another set it can still be processed without any issues. Changes to the Tests were made as well to reflect this new changes.
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.