### PR TITLE
Refactoring ISetLibrary

### DIFF
--- a/Sets Library/Sets Library/Interfaces/IRootElement.cs
+++ b/Sets Library/Sets Library/Interfaces/IRootElement.cs
@@ -1,10 +1,10 @@
 ﻿/*
- * File: IRootElements.cs
+ * File: IRootElement.cs
  * Author: Phiwokwakhe Khathwane
  * Date: 11 April 2025
  * 
  * Description:
- * This file contains the definition of the IRootElements interface, 
+ * This file contains the definition of the IRootElement interface, 
  * which establishes a contract for managing root-level elements within a set.
  * It provides methods for retrieving, adding, removing, and indexing 
  * elements that are considered "root elements" in the context of the set.
@@ -24,7 +24,7 @@ namespace SetsLibrary;
 /// of root-level elements within a set collection.
 /// </summary>
 /// <typeparam name="TElement">The type of the elements contained in the set.</typeparam>
-public interface IRootElements<TElement>
+public interface IRootElement<TElement>
 {
     /// <summary>
     /// Gets the count of root elements in the current set.

--- a/Sets Library/Sets Library/Interfaces/IRootElements.cs
+++ b/Sets Library/Sets Library/Interfaces/IRootElements.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * File: IRootElements.cs
+ * Author: Phiwokwakhe Khathwane
+ * Date: 11 April 2025
+ * 
+ * Description:
+ * This file contains the definition of the IRootElements interface, 
+ * which establishes a contract for managing root-level elements within a set.
+ * It provides methods for retrieving, adding, removing, and indexing 
+ * elements that are considered "root elements" in the context of the set.
+ * 
+ * Key Features:
+ * - Supports enumeration of root elements.
+ * - Allows adding and removing single or multiple elements.
+ * - Provides indexing capabilities for element lookup.
+ * - Generic and type-safe with support for any element type.
+ */
+
+namespace SetsLibrary;
+
+/// <summary>
+/// Defines a contract for managing the root elements of a set. 
+/// This interface supports enumeration, addition, removal, and indexing 
+/// of root-level elements within a set collection.
+/// </summary>
+/// <typeparam name="TElement">The type of the elements contained in the set.</typeparam>
+public interface IRootElements<TElement>
+{
+    /// <summary>
+    /// Gets the count of root elements in the current set.
+    /// </summary>
+    /// <value>
+    /// The total number of root elements contained in the set.
+    /// </value>
+    int CountRootElements { get; }
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the root elements of the current set.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}"/> that can be used to iterate through the root elements.
+    /// </returns>
+    IEnumerable<TElement> GetRootElementsEnumerator();
+
+    /// <summary>
+    /// Adds a single element to the root elements of the current set.
+    /// </summary>
+    /// <param name="element">The element to be added to the root elements collection.</param>
+    void AddElement(TElement element);
+
+    /// <summary>
+    /// Adds a range of elements to the root elements of the current set.
+    /// </summary>
+    /// <param name="elements">A collection of elements to add to the root.</param>
+    void AddRange(IEnumerable<TElement> elements);
+
+    /// <summary>
+    /// Removes an element from the root elements of the current set.
+    /// </summary>
+    /// <param name="element">The element to remove from the root.</param>
+    /// <returns>
+    /// <c>true</c> if the element was successfully removed; otherwise, <c>false</c>.
+    /// </returns>
+    bool RemoveElement(TElement element);
+
+    /// <summary>
+    /// Gets the index of the specified element within the root elements.
+    /// </summary>
+    /// <param name="element">The element to locate in the root elements collection.</param>
+    /// <returns>
+    /// The zero-based index of the element if found; otherwise, -1.
+    /// </returns>
+    int IndexOf(TElement element);
+} // interface
+// namespace

--- a/Sets Library/Sets Library/Interfaces/ISetTree.cs
+++ b/Sets Library/Sets Library/Interfaces/ISetTree.cs
@@ -23,7 +23,7 @@ namespace SetsLibrary;
 /// This interface provides methods to manipulate, retrieve, and manage elements and subsets in a sorted set tree.
 /// </summary>
 /// <typeparam name="T">The type of elements in the set, which must implement <see cref="IComparable{T}"/>.</typeparam>
-public interface ISetTree<T> : IRootElement<T>, IComparable<ISetTree<T>>
+public interface ISetTree<T> : IRootElement<T>, ISubTree<ISetTree<T>> ,IComparable<ISetTree<T>>
     where T : IComparable<T>
 {
     /// <summary>
@@ -43,14 +43,6 @@ public interface ISetTree<T> : IRootElement<T>, IComparable<ISetTree<T>>
     int Count { get; }
 
     /// <summary>
-    /// Gets the count of subsets contained within the current set.
-    /// </summary>
-    /// <value>
-    /// The number of nested subsets within the set.
-    /// </value>
-    int CountSubsets { get; }
-
-    /// <summary>
     /// Gets the set extraction settings associated with the current set.
     /// </summary>
     /// <value>
@@ -63,43 +55,6 @@ public interface ISetTree<T> : IRootElement<T>, IComparable<ISetTree<T>>
     ///  within a nested subsets will be ignored for the current set.
     /// </summary>
     SetTreeInfo TreeInfo { get; }
-    /// <summary>
-    /// Returns an enumerator that iterates through the subsets of the current set.
-    /// </summary>
-    /// <returns>
-    /// An enumerator that can be used to iterate through the subsets of the current set.
-    /// </returns>
-    IEnumerable<ISetTree<T>> GetSubsetsEnumerator();
-
-    /// <summary>
-    /// Adds a subset inside the current set.
-    /// </summary>
-    /// <param name="tree">The tree representation of the subset to be added.</param>
-    void AddSubSetTree(ISetTree<T> tree);
-
-    /// <summary>
-    /// Adds a range of subsets to the current set.
-    /// </summary>
-    /// <param name="subsets">The subsets to be added.</param>
-    void AddRange(IEnumerable<ISetTree<T>> subsets);
-
-    /// <summary>
-    /// Removes a subset from the current set.
-    /// </summary>
-    /// <param name="element">The subset to be removed.</param>
-    /// <returns>
-    /// A boolean value indicating whether the subset was successfully removed.
-    /// </returns>
-    bool RemoveElement(ISetTree<T> element);
-
-    /// <summary>
-    /// Gets the index of the specified subset in the nested sets of the current set.
-    /// </summary>
-    /// <param name="subset">The subset to search for.</param>
-    /// <returns>
-    /// The zero-based index of the subset within the current set, or -1 if the subset is not found.
-    /// </returns>
-    int IndexOf(ISetTree<T> subset);
 
     /// <summary>
     /// Gets the string representation of the current set tree.

--- a/Sets Library/Sets Library/Interfaces/ISetTree.cs
+++ b/Sets Library/Sets Library/Interfaces/ISetTree.cs
@@ -23,7 +23,7 @@ namespace SetsLibrary;
 /// This interface provides methods to manipulate, retrieve, and manage elements and subsets in a sorted set tree.
 /// </summary>
 /// <typeparam name="T">The type of elements in the set, which must implement <see cref="IComparable{T}"/>.</typeparam>
-public interface ISetTree<T> : IComparable<ISetTree<T>>
+public interface ISetTree<T> : IRootElement<T>, IComparable<ISetTree<T>>
     where T : IComparable<T>
 {
     /// <summary>
@@ -41,14 +41,6 @@ public interface ISetTree<T> : IComparable<ISetTree<T>>
     /// The number of elements in the current set.
     /// </value>
     int Count { get; }
-    
-    /// <summary>
-    /// Gets the count of root elements in the current set.
-    /// </summary>
-    /// <value>
-    /// The count of root elements in the set.
-    /// </value>
-    int CountRootElements { get; }
 
     /// <summary>
     /// Gets the count of subsets contained within the current set.
@@ -80,45 +72,16 @@ public interface ISetTree<T> : IComparable<ISetTree<T>>
     IEnumerable<ISetTree<T>> GetSubsetsEnumerator();
 
     /// <summary>
-    /// Returns an enumerator that iterates through the root elements of the current set.
-    /// </summary>
-    /// <returns>
-    /// An enumerator that can be used to iterate through the root elements of the current set.
-    /// </returns>
-    IEnumerable<T> GetRootElementsEnumerator();
-
-    /// <summary>
     /// Adds a subset inside the current set.
     /// </summary>
     /// <param name="tree">The tree representation of the subset to be added.</param>
     void AddSubSetTree(ISetTree<T> tree);
 
     /// <summary>
-    /// Adds a single element to the root elements of the current set.
-    /// </summary>
-    /// <param name="element">The element to be added to the root.</param>
-    void AddElement(T element);
-
-    /// <summary>
-    /// Adds a range of elements to the root elements of the current set.
-    /// </summary>
-    /// <param name="elements">The elements to be added.</param>
-    void AddRange(IEnumerable<T> elements);
-
-    /// <summary>
     /// Adds a range of subsets to the current set.
     /// </summary>
     /// <param name="subsets">The subsets to be added.</param>
     void AddRange(IEnumerable<ISetTree<T>> subsets);
-
-    /// <summary>
-    /// Removes an element from the root elements of the current set.
-    /// </summary>
-    /// <param name="element">The element to be removed.</param>
-    /// <returns>
-    /// A boolean value indicating whether the element was successfully removed.
-    /// </returns>
-    bool RemoveElement(T element);
 
     /// <summary>
     /// Removes a subset from the current set.
@@ -128,15 +91,6 @@ public interface ISetTree<T> : IComparable<ISetTree<T>>
     /// A boolean value indicating whether the subset was successfully removed.
     /// </returns>
     bool RemoveElement(ISetTree<T> element);
-
-    /// <summary>
-    /// Gets the index of the specified element in the root of the current set.
-    /// </summary>
-    /// <param name="element">The element to search for.</param>
-    /// <returns>
-    /// The zero-based index of the element within the root, or -1 if the element is not found.
-    /// </returns>
-    int IndexOf(T element);
 
     /// <summary>
     /// Gets the index of the specified subset in the nested sets of the current set.

--- a/Sets Library/Sets Library/Interfaces/ISubTree.cs
+++ b/Sets Library/Sets Library/Interfaces/ISubTree.cs
@@ -53,7 +53,7 @@ public interface ISubTree<T>
     /// Adds a range of subsets to the current set.
     /// </summary>
     /// <param name="subsets">A collection of subsets to be added to the set.</param>
-    void AddRange(T subsets);
+    void AddRange(IEnumerable<T> subsets);
 
     /// <summary>
     /// Removes a subset from the current set.

--- a/Sets Library/Sets Library/Interfaces/ISubTree.cs
+++ b/Sets Library/Sets Library/Interfaces/ISubTree.cs
@@ -25,7 +25,7 @@ namespace SetsLibrary;
 /// </summary>
 /// <typeparam name="T">The type of the set tree, which must implement <see cref="ISetTree{T}"/> and <see cref="IComparable{T}"/>.</typeparam>
 public interface ISubTree<T>
-    where T : ISetTree<T>, IComparable<T>
+    where T : IComparable<T>
 {
     /// <summary>
     /// Gets the count of subsets contained within the current set.
@@ -39,21 +39,21 @@ public interface ISubTree<T>
     /// Returns an enumerator that iterates through the subsets of the current set.
     /// </summary>
     /// <returns>
-    /// An <see cref="IEnumerable{ISetTree{T}}"/> that can be used to iterate through the subsets.
+    /// An <see cref="IEnumerable{T}"/> that can be used to iterate through the subsets.
     /// </returns>
-    IEnumerable<ISetTree<T>> GetSubsetsEnumerator();
+    IEnumerable<T> GetSubsetsEnumerator();
 
     /// <summary>
     /// Adds a subset (tree) inside the current set.
     /// </summary>
     /// <param name="tree">The tree representation of the subset to be added to the set.</param>
-    void AddSubSetTree(ISetTree<T> tree);
+    void AddSubSetTree(T tree);
 
     /// <summary>
     /// Adds a range of subsets to the current set.
     /// </summary>
     /// <param name="subsets">A collection of subsets to be added to the set.</param>
-    void AddRange(IEnumerable<ISetTree<T>> subsets);
+    void AddRange(T subsets);
 
     /// <summary>
     /// Removes a subset from the current set.
@@ -62,7 +62,7 @@ public interface ISubTree<T>
     /// <returns>
     /// A boolean value indicating whether the subset was successfully removed.
     /// </returns>
-    bool RemoveElement(ISetTree<T> element);
+    bool RemoveElement(T element);
 
     /// <summary>
     /// Gets the index of the specified subset in the nested sets of the current set.
@@ -71,6 +71,6 @@ public interface ISubTree<T>
     /// <returns>
     /// The zero-based index of the subset if found; otherwise, -1.
     /// </returns>
-    int IndexOf(ISetTree<T> subset);
+    int IndexOf(T subset);
 } // interface
 // namespace

--- a/Sets Library/Sets Library/Interfaces/ISubTree.cs
+++ b/Sets Library/Sets Library/Interfaces/ISubTree.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * File: ISubTree.cs
+ * Author: Phiwokwakhe Khathwane
+ * Date: 11 April 2025
+ * 
+ * Description:
+ * This file contains the definition of the ISubTree interface, 
+ * which provides a contract for managing nested subsets within a set.
+ * It allows operations such as retrieving, adding, removing, and indexing 
+ * subsets that are part of the current set, supporting hierarchical set structures.
+ * 
+ * Key Features:
+ * - Supports enumeration of nested subsets within a set.
+ * - Allows adding and removing single or multiple subsets.
+ * - Provides indexing capabilities for subset lookup.
+ * - Generic and type-safe with support for set trees.
+ */
+
+namespace SetsLibrary;
+
+/// <summary>
+/// Defines a contract for managing nested subsets (or subtrees) within a set.
+/// This interface provides methods for adding, removing, and indexing subsets, 
+/// allowing hierarchical structures within the set collection.
+/// </summary>
+/// <typeparam name="T">The type of the set tree, which must implement <see cref="ISetTree{T}"/> and <see cref="IComparable{T}"/>.</typeparam>
+public interface ISubTree<T>
+    where T : ISetTree<T>, IComparable<T>
+{
+    /// <summary>
+    /// Gets the count of subsets contained within the current set.
+    /// </summary>
+    /// <value>
+    /// The number of nested subsets within the set.
+    /// </value>
+    int CountSubsets { get; }
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the subsets of the current set.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="IEnumerable{ISetTree{T}}"/> that can be used to iterate through the subsets.
+    /// </returns>
+    IEnumerable<ISetTree<T>> GetSubsetsEnumerator();
+
+    /// <summary>
+    /// Adds a subset (tree) inside the current set.
+    /// </summary>
+    /// <param name="tree">The tree representation of the subset to be added to the set.</param>
+    void AddSubSetTree(ISetTree<T> tree);
+
+    /// <summary>
+    /// Adds a range of subsets to the current set.
+    /// </summary>
+    /// <param name="subsets">A collection of subsets to be added to the set.</param>
+    void AddRange(IEnumerable<ISetTree<T>> subsets);
+
+    /// <summary>
+    /// Removes a subset from the current set.
+    /// </summary>
+    /// <param name="element">The subset to be removed from the set.</param>
+    /// <returns>
+    /// A boolean value indicating whether the subset was successfully removed.
+    /// </returns>
+    bool RemoveElement(ISetTree<T> element);
+
+    /// <summary>
+    /// Gets the index of the specified subset in the nested sets of the current set.
+    /// </summary>
+    /// <param name="subset">The subset to search for within the current set.</param>
+    /// <returns>
+    /// The zero-based index of the subset if found; otherwise, -1.
+    /// </returns>
+    int IndexOf(ISetTree<T> subset);
+} // interface
+// namespace


### PR DESCRIPTION
## Describe your changes
Added few interfaces, namely `ISubTree` and `IRootElement` which will define the methods and properties for the respective collections. The `ISetTree` interface was broken down with respect to these interfaces and reduce it's load. 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

## What's next
The two mentioned interfaces can be abstracted as well since the method are the same. A same approach used on the abstractions with `ISortedCollection` can be used here as well.
