### PR TITLE
Feature/config braces

### DIFF
--- a/Sets Library/Sets Library/Models/CustomSetsConfigurations.cs
+++ b/Sets Library/Sets Library/Models/CustomSetsConfigurations.cs
@@ -20,12 +20,13 @@ internal class CustomSetsConfigurations<TObject> : SetsConfigurations
     public Func<string?[], TObject>? Funct_ToObject { get; set; } = null;
 
     /// <inheritdoc/>
-    public CustomSetsConfigurations(string rowTerminator) : base(rowTerminator)
+    public CustomSetsConfigurations(string rowTerminator, bool addBraces) : base(rowTerminator, addBraces)
     {
         IsICustomObject = true;
     }
     /// <inheritdoc/>
-    public CustomSetsConfigurations(string fieldTerminator, string rowTerminator, bool ignoreEmptySets) : base(fieldTerminator, rowTerminator,ignoreEmptySets)
+    public CustomSetsConfigurations(string fieldTerminator, string rowTerminator, bool ignoreEmptySets, bool addBraces) 
+        : base(fieldTerminator, rowTerminator,ignoreEmptySets, addBraces)
     {
         IsICustomObject = true;
     }

--- a/Sets Library/Sets Library/Models/Sets/BaseSet.cs
+++ b/Sets Library/Sets Library/Models/Sets/BaseSet.cs
@@ -146,12 +146,16 @@ public abstract class BaseSet<T> : IStructuredSet<T>
         // Ensure the configuration is not null, as it is needed to extract elements and subsets from the expression
         ArgumentNullException.ThrowIfNull(config, nameof(config));
 
+        //Add braces if needed
+        expression = AddBracesIfNeeded(expression, config);
+
         // Ensure the expression is valid (non-null and non-whitespace)
         ArgumentException.ThrowIfNullOrWhiteSpace(expression, nameof(expression));
 
         // Assign the configurations
         this.ExtractionConfiguration = ModifyConfigurations(config);
         // BuildSetTree the set tree from the provided expression and configuration
+
         _treeWrapper = new SetTreeWithIndexes<T>(Extractions(expression));
 
         // Assign the original expression after extraction
@@ -202,7 +206,16 @@ public abstract class BaseSet<T> : IStructuredSet<T>
             throw new SetsException("Failed to extract set string.", "", ex);
         }
     } // Extractions
-
+    private string AddBracesIfNeeded(string expression, SetsConfigurations config)
+    {
+        ArgumentNullException.ThrowIfNull(expression, nameof (expression));
+        //Check if we need to add braces or not
+        if(config.AutomaticallyAddBrace)
+            return "{" + expression + "}";
+        
+        //Just return the expression itself.
+        return expression;
+    }
     /// <summary>
     /// Checks if the current instance is a custom object set.
     /// </summary>

--- a/Sets Library/Sets Library/Models/Sets/CustomObjectSet.cs
+++ b/Sets Library/Sets Library/Models/Sets/CustomObjectSet.cs
@@ -67,10 +67,10 @@ public class CustomObjectSet<T> : BaseSet<T>
     protected sealed override SetsConfigurations ModifyConfigurations(SetsConfigurations config)
     {
         //Here we create a new instance of the Extraction settings using the properties we had
-        var configNew = new CustomSetsConfigurations<T>(config.FieldTerminator, config.RowTerminator,config.IgnoreEmptySets);
+        var configNew = new CustomSetsConfigurations<T>(config.FieldTerminator, config.RowTerminator,config.IgnoreEmptySets, config.AutomaticallyAddBrace);
         //Set the method for converting
         configNew.Funct_ToObject = ToObject;
-        //Ovverride the base configuration with the new one
+        //Override the base configuration with the new one
         return configNew;
     }
 

--- a/Sets Library/Sets Library/Models/SetsConfigurations.cs
+++ b/Sets Library/Sets Library/Models/SetsConfigurations.cs
@@ -45,20 +45,26 @@ public class SetsConfigurations
     /// Get a values indicating whether empty cells should be ignored or not.
     /// </summary>
     public bool IgnoreEmptySets { get;private set; }
+    /// <summary>
+    /// Get a values to indicate if braces can be automatically added.
+    /// </summary>
+    internal bool AutomaticallyAddBrace { get; private set; }
     // Constructors
     /// <summary>
     /// Initializes a new instance of the <see cref="SetsConfigurations"/> class with a row terminators. The
     /// default field is tab character(\t). 
     /// </summary>
-    /// <param name="elementSeperator">The string used to separate rows in the data.</param>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="elementSeperator"/> is null.</exception>
-    /// <exception cref="SetsConfigurationException">Thrown if the default field terminator is the same as <paramref name="elementSeperator"/> or if they contain reserved characters.</exception>
-    public SetsConfigurations(string elementSeperator)
+    /// <param name="elementSeparator">The string used to separate rows in the data.</param>
+    /// <param name="addBraces">If true then braces will be automatically added.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="elementSeparator"/> is null.</exception>
+    /// <exception cref="SetsConfigurationException">Thrown if the default field terminator is the same as <paramref name="elementSeparator"/> or if they contain reserved characters.</exception>
+    public SetsConfigurations(string elementSeparator, bool addBraces = false)
     {
         string fieldTerminator = "\t";
-        VerifyProperties(fieldTerminator, elementSeperator);
+        VerifyProperties(fieldTerminator, elementSeparator);
         IsICustomObject = false;
         IgnoreEmptySets = true;
+        AutomaticallyAddBrace = addBraces;
     }
 
     /// <summary>
@@ -67,13 +73,15 @@ public class SetsConfigurations
     /// <param name="fieldTerminator">The string used to separate fields in a record.</param>
     /// <param name="rowTerminator">The string used to separate rows in the data.</param>
     /// <param name="ignoreEmptyFields">If true, empty sets or null elements will be ignored.</param>
+    /// <param name="addBraces">If true then braces will be automatically added.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="fieldTerminator"/> or <paramref name="rowTerminator"/> is null.</exception>
     /// <exception cref="SetsConfigurationException">Thrown if <paramref name="fieldTerminator"/> is the same as <paramref name="rowTerminator"/> or if they contain reserved characters.</exception>
-    public SetsConfigurations(string fieldTerminator, string rowTerminator, bool ignoreEmptyFields = true)
+    public SetsConfigurations(string fieldTerminator, string rowTerminator, bool ignoreEmptyFields = true, bool addBraces = false)
     {
         VerifyProperties(fieldTerminator, rowTerminator);
         IsICustomObject = false;
         IgnoreEmptySets = ignoreEmptyFields;
+        AutomaticallyAddBrace = addBraces;
     }
 
     /// <summary>

--- a/Sets Library/SetsLibrary.Tests/New features/AddBracesPropertyFeature.cs
+++ b/Sets Library/SetsLibrary.Tests/New features/AddBracesPropertyFeature.cs
@@ -1,0 +1,46 @@
+﻿using SetsLibrary;
+using Xunit;
+using System;
+namespace SetsLibrary.Tests.New_features;
+
+public class AddBracesPropertyFeature
+{
+    [Fact]
+    public void AddBracesWithEmptyString_ShouldReturn_EmptySet()
+    {
+        //Arrange
+        string expression = "";
+        var config = new SetsConfigurations(",",addBraces: true);
+
+        //Act
+        var set = new TypedSet<int>(expression, config);
+
+        //Assert
+        Assert.Equal(set.BuildStringRepresentation(), "{}");
+    }
+
+    [Fact]
+    public void AddBracesWithEmptyString_ShouldNotThrowException()
+    {
+        //Assert
+        string expression = "";
+        var config = new SetsConfigurations(",", addBraces: true);
+
+        //Arrange 
+        var ex = Record.Exception(() => new TypedSet<int>(expression, config));
+        
+            
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void EmptyStringSet_ShouldThrowException()
+    {
+        //Assert
+        string expression = "";
+        var config = new SetsConfigurations(",", addBraces: false);
+
+        //This should pass
+        Assert.Throws<ArgumentException>(() => new TypedSet<int>(expression, config));
+    }
+}//class


### PR DESCRIPTION
## Describe your changes
Added a new feature to the Configurations of the sets class. This will allow to dynamically add braces in the expression even if you did not have them, this can be done by specifying the argument `addBraces = true` in the constructor of `SetsConfigurations`

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.