### PR TITLE
Tests/sets extraction configurations

### DIFF
--- a/Sets Library/Sets Library/Models/SetsConfigurations.cs
+++ b/Sets Library/Sets Library/Models/SetsConfigurations.cs
@@ -66,7 +66,7 @@ public class SetsConfigurations
         IsICustomObject = false;
         IgnoreEmptySets = true;
         AutomaticallyAddBrace = addBraces;
-        IgnoreEmptySets |= ignoreEmptyFields;
+        IgnoreEmptySets = ignoreEmptyFields;
     }
 
     /// <summary>

--- a/Sets Library/Sets Library/Utility/SetTreeBuilder.cs
+++ b/Sets Library/Sets Library/Utility/SetTreeBuilder.cs
@@ -62,18 +62,17 @@ public class SetTreeBuilder<T>
         ISetTree<T> tree = BuildSetTree(root, extractionConfig);
 
         // Add all subsets as subtrees
-        while (subsets.Count > 0)
+        foreach (var subset in subsets)
         {
-            string ex = subsets.Pop();
-            tree.AddElement(BuildSetTree(ex, extractionConfig));
+            tree.AddElement(BuildSetTree(subset, extractionConfig));
         }
 
         return tree;
     }//BuildSetTree
-    private static Stack<string> ExtractSubsets(string expression,int lenRowTerminator ,out string rootElements)
+    private static SortedCollection<string> ExtractSubsets(string expression,int lenRowTerminator ,out string rootElements)
     {
         //Here the first braces have been removed 
-        Stack<string> subsets = [];
+        SortedCollection<string> subsets = [];
 
         //String builders to hold the current subset and current root
         StringBuilder _roots = new();
@@ -119,7 +118,7 @@ public class SetTreeBuilder<T>
                 {
                     //Here it means that the subset has been extracted
                     //-We need to add the subset
-                    subsets.Push(_subSet.ToString());
+                    subsets.AddIfUnique(_subSet.ToString());
 
                     //Reset the subset 
                     _subSet.Clear();

--- a/Sets Library/Sets Library/Utility/SetTreeUtility.cs
+++ b/Sets Library/Sets Library/Utility/SetTreeUtility.cs
@@ -54,13 +54,17 @@ public static class SetTreeUtility<T>
         }
 
         //Here the tree is none empty(it has something in it)
-        string representation = "{";
+        string representation = "{" + currentTree.RootElements;
 
         //Check for empty sets
         if (currentTree.TreeInfo.HasNullElements && !currentTree.ExtractionSettings.IgnoreEmptySets)
-            representation += "{}";
-        
-         representation += currentTree.RootElements; 
+        {
+            if (representation.Length == 1)//Here it means there's only the opening brace without clossing braces
+                representation += "{}";
+            else
+                representation += currentTree.ExtractionSettings.RowTerminator + "{}";
+        }
+
 
         //Loop through the subsets
         foreach (var subset in currentTree.GetSubsetsEnumerator())

--- a/Sets Library/Sets Library/Utility/SetTreeUtility.cs
+++ b/Sets Library/Sets Library/Utility/SetTreeUtility.cs
@@ -55,6 +55,7 @@ public static class SetTreeUtility<T>
 
         //Here the tree is none empty(it has something in it)
         string representation = "{" + currentTree.RootElements;
+        bool emptyAdded = false;
 
         //Check for empty sets
         if (currentTree.TreeInfo.HasNullElements && !currentTree.ExtractionSettings.IgnoreEmptySets)
@@ -63,12 +64,16 @@ public static class SetTreeUtility<T>
                 representation += "{}";
             else
                 representation += currentTree.ExtractionSettings.RowTerminator + "{}";
+            emptyAdded = true;
         }
 
 
         //Loop through the subsets
         foreach (var subset in currentTree.GetSubsetsEnumerator())
         {
+            if (emptyAdded && subset.TreeInfo.IsEmptyTree)
+                continue;//Ignore tree since it has been handled
+
             //Attach each subset in the representation
             string subsetTree = BuildTree(subset);
             representation += subset.ExtractionSettings.RowTerminator + subsetTree;

--- a/Sets Library/SetsLibrary.Tests/New features/AddBracesPropertyFeature.cs
+++ b/Sets Library/SetsLibrary.Tests/New features/AddBracesPropertyFeature.cs
@@ -2,6 +2,7 @@
 using Xunit;
 using System;
 using SetsLibrary.Utility;
+using SetsLibrary.Extensions;
 namespace SetsLibrary.Tests.New_features;
 
 public class AddBracesPropertyFeature
@@ -42,7 +43,7 @@ public class AddBracesPropertyFeature
         var config = new SetsConfigurations(",", addBraces: false);
 
         //This should pass
-        Assert.Throws<ArgumentException>(() => new TypedSet<int>(expression, config));
+        Assert.Throws<MissingBraceException>(() => new TypedSet<int>(expression, config));
     }
     [Fact]
     public void BuildSetTree_SimpleSet_ParsesCorrectly()
@@ -69,4 +70,22 @@ public class AddBracesPropertyFeature
 
         Assert.Equal(3, result.CountRootElements);
     }
+    //[Fact]
+    //public void BuildSetTree_WithBraces_CreatesSubset()
+    //{
+    //    var config = new SetsConfigurations(",", addBraces: true);
+    //    string input = "{2,1,2,3,1}";
+    //    var set = new TypedSet<int>(input, config);
+
+    //    var result = set.
+
+
+    //    Assert.Equal(0, result.CountRootElements);
+    //    Assert.Equal(1, result.CountSubsets);
+    //    Assert.Equal(1, result.Count);
+    //    Assert.Empty(result.RootElements);
+    //    Assert.Empty(result.GetRootElementsEnumerator());
+    //    Assert.NotEmpty(result.GetSubsetsEnumerator());
+    //    Assert.Equal("{1,2,3}", result.GetSubsetsEnumerator().First().ToString());
+    //}
 }//class

--- a/Sets Library/SetsLibrary.Tests/New features/SetsTreeBuilderWithNullSets.cs
+++ b/Sets Library/SetsLibrary.Tests/New features/SetsTreeBuilderWithNullSets.cs
@@ -4,86 +4,210 @@ using Xunit;
 namespace SetsLibrary.Tests.New_features;
 public class SetsTreeBuilderWithNullSets
 {
-    //[Fact]
-    //public void BuildSetTree_EmptySetExpression_ReturnsEmptyTree()
-    //{
-    //    // Arrange
-    //    var config = new SetsConfigurations(",", ignoreEmptyFields: false);
-    //    string input = "{}";
+    [Fact]
+    public void BuildSetTree_EmptySetExpression_ReturnsEmptyTree()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{}";
 
-    //    // Act
-    //    var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
 
-    //    // Assert
-    //    Assert.Equal("{}", result.ToString());
-    //    Assert.Equal(0, result.CountRootElements);
-    //    Assert.Equal(0, result.CountSubsets);
-    //}
+        // Assert
+        Assert.Equal("{}", result.ToString());
+        Assert.Equal(0, result.CountRootElements);
+        Assert.Equal(0, result.CountSubsets);
+    }
 
-    //[Fact]
-    //public void BuildSetTree_EmptyElements_NotIgnored_AppendsEmptySetSymbol()
-    //{
-    //    // Arrange
-    //    var config = new SetsConfigurations(",", ignoreEmptyFields: false);
-    //    string input = "{,}"; // empty elements
+    [Fact]
+    public void BuildSetTree_EmptyElements_NotIgnored_AppendsEmptySetSymbol()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{,}"; // empty elements
 
-    //    // Act
-    //    var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
 
-    //    // Assert
-    //    Assert.Equal("{{}{}}", result.ToString()); // two empty elements shown as {}
-    //    Assert.True(result.TreeInfo.HasNullElements);
-    //}
+        // Assert
+        Assert.Equal("{}", result.ToString()); //
+        Assert.True(result.TreeInfo.HasNullElements);
+    }
 
-    //[Fact]
-    //public void BuildSetTree_EmptyElementAndValidElements_MixedToString()
-    //{
-    //    // Arrange
-    //    var config = new SetsConfigurations(",", ignoreEmptyFields: false);
-    //    string input = "{1,,3}";
+    [Fact]
+    public void BuildSetTree_EmptyElementAndValidElements_MixedToString()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{1,,3}";
 
-    //    // Act
-    //    var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
 
-    //    // Assert
-    //    Assert.Equal("{{}1,3}", result.ToString());
-    //    Assert.True(result.TreeInfo.HasNullElements);
-    //    Assert.Equal(2, result.CountRootElements); // 1 and 3 only
-    //}
+        // Assert
+        Assert.Equal("{1,3,{}}", result.ToString());
+        Assert.True(result.TreeInfo.HasNullElements);
+        Assert.Equal(2, result.CountRootElements); // 1 and 3 only
+    }
 
-    //[Fact]
-    //public void BuildSetTree_EmptyNestedSubset_PrintsAsEmptySet()
-    //{
-    //    // Arrange
-    //    var config = new SetsConfigurations(",", ignoreEmptyFields: false);
-    //    string input = "{1,2,{},3}";
+    [Fact]
+    public void BuildSetTree_EmptyNestedSubset_PrintsAsEmptySet()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{1,2,{},3}";
 
-    //    // Act
-    //    var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
 
-    //    // Assert
-    //    string output = result.ToString();
-    //    Assert.Contains("{}", output); // empty nested subset
-    //    Assert.Equal(3, result.CountRootElements);
-    //    Assert.Equal(1, result.CountSubsets);
+        // Assert
+        string output = result.ToString();
+        Assert.Contains("{}", output); // empty nested subset
+        Assert.Equal(3, result.CountRootElements);
+        Assert.Equal(1, result.CountSubsets);
 
-    //    var nested = Assert.Single(result.GetSubsetsEnumerator());
-    //    Assert.Equal("{}", nested.ToString());
-    //    Assert.True(nested.TreeInfo.IsEmptyTree);
-    //}
+        var nested = Assert.Single(result.GetSubsetsEnumerator());
+        Assert.Equal("{}", nested.ToString());
+        Assert.True(nested.TreeInfo.IsEmptyTree);
+    }
 
-    //[Fact]
-    //public void BuildSetTree_EmptySet_WithIgnoreFlag_DoesNotPrintBraces()
-    //{
-    //    // Arrange
-    //    var config = new SetsConfigurations(",", ignoreEmptyFields: true);
-    //    string input = "{1,,3}";
+    [Fact]
+    public void BuildSetTree_EmptySet_WithIgnoreFlag_DoesNotPrintBraces()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: true);
+        string input = "{1,,3}";
 
-    //    // Act
-    //    var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
 
-    //    // Assert
-    //    Assert.Equal("{1,3}", result.ToString());
-    //    Assert.False(result.TreeInfo.HasNullElements); // ignored
-    //}
+        // Assert
+        Assert.Equal("{1,3}", result.ToString());
+        Assert.True(result.TreeInfo.HasNullElements);//Shout stull have null elements
+    }
+    [Fact]
+    public void BuildSetTree_EmptyElementsInMixedSet_HandlesEmptyValues()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{1,,2,1,3,4,1,,8, ,6}"; // Some empty elements between valid values
+
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+
+        // Assert
+        Assert.Equal("{1,2,3,4,6,8,{}}", result.ToString());
+        Assert.True(result.TreeInfo.HasNullElements); // empty elements handled
+    }
+
+    [Fact]
+    public void BuildSetTree_EmptySetWithinSetWithMultipleEmptyElements_ReturnsExpectedTree()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{1,,2,3,{,}}"; // Nested empty set
+
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+
+        // Assert
+        Assert.Equal("{1,2,3,{}}", result.ToString());
+        Assert.Equal(3, result.CountRootElements); // 1, 2, and 3
+        Assert.Equal(1, result.CountSubsets); // one nested empty set
+    }
+
+    [Fact]
+    public void BuildSetTree_IgnoreEmptyFields_EmptyElementsAreIgnored()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: true);
+        string input = "{1,,2,1,3,4,1,,8, ,6}"; // Empty elements should be ignored
+
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+
+        // Assert
+        Assert.Equal("{1,2,3,4,6,8}", result.ToString()); // Empty values omitted
+        Assert.True(result.TreeInfo.HasNullElements); //Should still have null elements
+    }
+
+    [Fact]
+    public void BuildSetTree_EmptySetInTheMiddle_ReturnsCorrectStringRepresentation()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{5,6,,8,}"; // Empty element between 6 and 8
+
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+
+        // Assert
+        Assert.Equal("{5,6,8,{}}", result.ToString());
+        Assert.Equal(3, result.CountRootElements); // 5, 6, and 8
+        Assert.True(result.TreeInfo.HasNullElements); // Empty elements included
+    }
+
+    [Fact]
+    public void BuildSetTree_EmptySetsInComplexTree_NestedAndFlat()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{1,,2,{},3,{}}"; // Two empty sets
+
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+
+        // Assert
+        Assert.Equal("{1,2,3,{}}", result.ToString());
+        Assert.Equal(3, result.CountRootElements); // 1, 2, and 3
+        Assert.Equal(1, result.CountSubsets); // Two empty subsets
+    }
+
+    [Fact]
+    public void BuildSetTree_EmptySetsInSubsets_ShouldPrintCorrectly()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{1,{},{},3,{2}}"; // Empty sets in subsets
+
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+
+        // Assert
+        Assert.Equal("{1,3,{},{2}}", result.ToString());
+        Assert.Equal(2, result.CountRootElements); // Root element: 1
+        Assert.Equal(2, result.CountSubsets); // Two subsets, with empty sets
+    }
+
+    [Fact]
+    public void BuildSetTree_MultipleConsecutiveEmptyElements_ShouldBeHandledCorrectly()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{1,,,,,,2}"; // Multiple consecutive empty elements
+
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+
+        // Assert
+        Assert.Equal("{1,2,{}}", result.ToString());
+        Assert.True(result.TreeInfo.HasNullElements); // Empty elements handled as {}
+    }
+
+    [Fact]
+    public void BuildSetTree_EmptySetWithElementsAtEnd_ShouldNotAffectStructure()
+    {
+        // Arrange
+        var config = new SetsConfigurations(",", ignoreEmptyFields: false);
+        string input = "{1,2,3,,}"; // Empty at the end
+
+        // Act
+        var result = SetTreeBuilder<int>.BuildSetTree(input, config);
+
+        // Assert
+        Assert.Equal("{1,2,3,{}}", result.ToString());
+        Assert.True(result.TreeInfo.HasNullElements); // Empty elements handled as {}
+    }
+
 }///class


### PR DESCRIPTION
## Describe your changes
Added comprehensive xUnit tests to validate the handling of empty set elements in `SetTreeBuilder<T>`. These tests include scenarios.

## Checklist before requesting a review
- [x] I have performed a self-review of my code  
- [x] If it is a core feature, I have added thorough tests.
