### PR TITLE
moved extensions to collections namespaces

### DIFF
--- a/Sets Library/Sets Library/Extensions/SetTreeExtensions.cs
+++ b/Sets Library/Sets Library/Extensions/SetTreeExtensions.cs
@@ -19,11 +19,8 @@
  * - TElement must implement IComparable<TElement> for proper element comparison within the set.
  * - Specific conversion methods also support additional constraints like IConvertible and ICustomObjectConverter<TElement>.
  */
-
-using SetsLibrary.Collections;
 using System.Diagnostics.CodeAnalysis;
-
-namespace SetsLibrary.Extensions
+namespace SetsLibrary.Collections
 {
     /// <summary>
     /// Provides extension methods for converting <see cref="ISetTree{TElement}"/> objects into different collection types.

--- a/Sets Library/SetsLibrary.Tests/New features/AddBracesPropertyFeature.cs
+++ b/Sets Library/SetsLibrary.Tests/New features/AddBracesPropertyFeature.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using System;
 using SetsLibrary.Utility;
-using SetsLibrary.Extensions;
+using SetsLibrary.Collections;
 namespace SetsLibrary.Tests.New_features;
 
 public class AddBracesPropertyFeature


### PR DESCRIPTION
## Describe your changes
Move all the collections extensions to `Collections` namespace. This includes all methods that in the class `SetTreeExtensions`

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.