### PR TITLE
Rename methods

### DIFF
--- a/Sets Library/Sets Library/Collections/Element collections/ISortedCollection.cs
+++ b/Sets Library/Sets Library/Collections/Element collections/ISortedCollection.cs
@@ -69,13 +69,13 @@ public interface ISortedCollection<TElementContained> : IEnumerable<TElementCont
     /// Adds an element to the collection in sorted order. Repeated elements will be added.
     /// </summary>
     /// <param name="value">The value to be added, of type <typeparamref name="TElementContained"/>.</param>
-    void Add(TElementContained value);
+    void AddIfDuplicate(TElementContained value);
 
     /// <summary>
     /// Adds an element to the collection in sorted order and ignore duplicates
     /// </summary>
     /// <param name="val">The value to be added, of type <typeparamref name="TElementContained"/></param>
-    void AddIfUnique(TElementContained val);
+    void Add(TElementContained val);
 
     /// <summary>
     /// Adds a range of elements to the collection in sorted order.

--- a/Sets Library/Sets Library/Collections/Element collections/SortedCollection.cs
+++ b/Sets Library/Sets Library/Collections/Element collections/SortedCollection.cs
@@ -88,7 +88,7 @@ public class SortedCollection<TElement> : ISortedCollection<TElement>
     ///</summary>
     ///<param name="value">The element to add.</param>
     ///<exception cref="ArgumentNullException">Thrown if the element is null.</exception>
-    public void Add(TElement value)
+    public void AddIfDuplicate(TElement value)
     {
         //Don't add if null
         ArgumentNullException.ThrowIfNull(value, nameof(value));
@@ -103,13 +103,13 @@ public class SortedCollection<TElement> : ISortedCollection<TElement>
         //Find the index for insertion
         int pointOfInsertion = FindIndexOfInsertion(value);
         _elements.Insert(pointOfInsertion, value);
-    }//Add
+    }//AddIfDuplicate
     ///<summary>
     ///Adds an element to the collection, ensuring the collection remains sorted. Duplicates will not be added.
     ///</summary>
     ///<param name="val">The element to add.</param>
     ///<exception cref="ArgumentNullException">Thrown if the element is null.</exception>
-    public void AddIfUnique(TElement val)
+    public void Add(TElement val)
     {
         //Don't add if null
         ArgumentNullException.ThrowIfNull(val, nameof(val));
@@ -123,13 +123,13 @@ public class SortedCollection<TElement> : ISortedCollection<TElement>
 
         int indexOfInsertion = FindIndexOfInsertion(val);
 
-        //Check if element can be added
-        if (indexOfInsertion < Count && _elements[indexOfInsertion].CompareTo(val) == 0) //Here it means it is defined
+        //Only add unique elements
+        if (indexOfInsertion < Count && _elements[indexOfInsertion].CompareTo(val) == 0) 
             return;
 
-        //Else add
+        
         _elements.Insert(indexOfInsertion, val);
-    }//AddIfUnique
+    }//Add
     ///<summary>
     ///Finds the index at which the specified value should be inserted to maintain sorted order.
     ///</summary>
@@ -169,7 +169,7 @@ public class SortedCollection<TElement> : ISortedCollection<TElement>
 
         foreach (var item in coll)
         {
-            Add(item);
+            AddIfDuplicate(item);
         }
     }//AddRange
 

--- a/Sets Library/Sets Library/Collections/Sets collections/ISetCollection.cs
+++ b/Sets Library/Sets Library/Collections/Sets collections/ISetCollection.cs
@@ -17,7 +17,7 @@
  * - Indexer for retrieving sets by their name.
  * - Name-based searching and removal of sets.
  * - Enumeration of sets both as structures and as individual elements.
- * - Methods for dynamic manipulation: Add, AddRange, Contains, Remove, Reset, and Clear.
+ * - Methods for dynamic manipulation: AddIfDuplicate, AddRange, Contains, Remove, Reset, and Clear.
  * - Each element in the set must implement <see cref="IComparable{T}"/> for ordering and comparison.
  */
 namespace SetsLibrary.Collections;

--- a/Sets Library/Sets Library/Collections/Sets collections/SetCollection.cs
+++ b/Sets Library/Sets Library/Collections/Sets collections/SetCollection.cs
@@ -79,7 +79,7 @@ public class SetCollection<T> : ISetCollection<IStructuredSet<T>, T>
         // Check for nulls
         ArgumentNullException.ThrowIfNull(collection, nameof(collection));
 
-        // Add the range
+        // AddIfDuplicate the range
         this.AddRange(collection);
     }
 
@@ -99,7 +99,7 @@ public class SetCollection<T> : ISetCollection<IStructuredSet<T>, T>
         //Generate the next key
         string key = GenerateNextKey();
 
-        // Add the element
+        // AddIfDuplicate the element
         _dicCollection.Add(key, item);
     }
     private string GenerateNextKey()

--- a/Sets Library/Sets Library/Models/CustomSetsConfigurations.cs
+++ b/Sets Library/Sets Library/Models/CustomSetsConfigurations.cs
@@ -16,7 +16,7 @@ namespace SetsLibrary;
 internal class CustomSetsConfigurations<TObject> : SetsConfigurations
     where TObject : IComparable<TObject>
 {
-    //Add an additional feature for custom conversion
+    //AddIfDuplicate an additional feature for custom conversion
     public Func<string?[], TObject>? Funct_ToObject { get; set; } = null;
 
     /// <inheritdoc/>

--- a/Sets Library/Sets Library/Models/SetTree/SetTree.cs
+++ b/Sets Library/Sets Library/Models/SetTree/SetTree.cs
@@ -90,7 +90,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
     public SetTree(SetsConfigurations extractionSettings, IEnumerable<T> elements)
         : this(extractionSettings)
     {
-        //Add elements as ranges
+        //AddIfDuplicate elements as ranges
         this.AddRange(elements);
     }
 
@@ -102,7 +102,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
     public SetTree(SetsConfigurations extractionSettings, IEnumerable<ISetTree<T>> subsets)
         : this(extractionSettings)
     {
-        //Add elements as ranges
+        //AddIfDuplicate elements as ranges
         this.AddRange(subsets);
     }
 
@@ -115,7 +115,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
     public SetTree(SetsConfigurations extractionSettings, IEnumerable<T> elements, IEnumerable<ISetTree<T>> subsets)
         : this(extractionSettings)
     {
-        //Add ranges
+        //AddIfDuplicate ranges
         this.AddRange(elements);
         this.AddRange(subsets);
     }
@@ -151,8 +151,8 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
             this.TreeInfo.IsEmptyTree = false;
         }
 
-        //Add element if it is unique
-        _elements.AddIfUnique(element);
+        //AddIfDuplicate element if it is unique
+        _elements.Add(element);
     }
 
     /// <summary>
@@ -164,7 +164,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
         //Check for nulls
         ArgumentNullException.ThrowIfNull(elements, nameof(elements));
 
-        //Add them one by one
+        //AddIfDuplicate them one by one
         foreach (T element in elements)
             this.AddElement(element);
     }
@@ -181,14 +181,14 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
         //First check if it is a null set or not
         if (tree.TreeInfo.IsEmptyTree)
         {
-            //Add it as a null set
+            //AddIfDuplicate it as a null set
             WillHaveNullElements(true, 1);
         }
         //Update the current's tree info
         TreeInfo.IsEmptyTree = false;
 
-        //Add if unique
-        _subSets.AddIfUnique(tree);
+        //AddIfDuplicate if unique
+        _subSets.Add(tree);
     }
 
     /// <summary>
@@ -200,7 +200,7 @@ public class SetTree<T> : ISetTree<T> where T : IComparable<T>
         //Check for nulls
         ArgumentNullException.ThrowIfNull(subsets, nameof(subsets));
 
-        //Add subsets one by one
+        //AddIfDuplicate subsets one by one
         foreach (ISetTree<T> subset in subsets)
             this.AddElement(subset);
     }

--- a/Sets Library/Sets Library/Models/Sets/BaseSet.cs
+++ b/Sets Library/Sets Library/Models/Sets/BaseSet.cs
@@ -146,7 +146,7 @@ public abstract class BaseSet<T> : IStructuredSet<T>
         // Ensure the configuration is not null, as it is needed to extract elements and subsets from the expression
         ArgumentNullException.ThrowIfNull(config, nameof(config));
 
-        //Add braces if needed
+        //AddIfDuplicate braces if needed
         expression = AddBracesIfNeeded(expression, config);
 
         // Ensure the expression is valid (non-null and non-whitespace)
@@ -242,7 +242,7 @@ public abstract class BaseSet<T> : IStructuredSet<T>
         //Check if element is null or not
         ArgumentNullException.ThrowIfNull(element, nameof(element));
 
-        //Add element to the tree
+        //AddIfDuplicate element to the tree
         _treeWrapper.AddElement(element);
     }//AddElement
 
@@ -293,7 +293,7 @@ public abstract class BaseSet<T> : IStructuredSet<T>
         var tree = Extractions(subset);
 
         var indexedTree = BuildNewSet(new SetTreeWithIndexes<T>(tree));
-        //Add the tree
+        //AddIfDuplicate the tree
         this.AddElement(indexedTree);
     }//AddSubsetAsString
 

--- a/Sets Library/Sets Library/Utility/BraceEvaluator.cs
+++ b/Sets Library/Sets Library/Utility/BraceEvaluator.cs
@@ -60,7 +60,7 @@ public static class BraceEvaluator
             // Check for opening brace
             if (character == '{')
             {
-                elements.Push(character); // Add the opening brace to the stack
+                elements.Push(character); // AddIfDuplicate the opening brace to the stack
                 continue;
             }
 

--- a/Sets Library/Sets Library/Utility/SetTreeBuilder.cs
+++ b/Sets Library/Sets Library/Utility/SetTreeBuilder.cs
@@ -62,7 +62,7 @@ public class SetTreeBuilder<T>
         // Create the root tree with the remaining elements after removing subsets
         ISetTree<T> tree = BuildSetTree(root, extractionConfig);
 
-        // Add all subsets as subtrees
+        // AddIfDuplicate all subsets as subtrees
         foreach (var subset in subsets)
         {
             tree.AddElement(BuildSetTree(subset, extractionConfig));
@@ -119,7 +119,7 @@ public class SetTreeBuilder<T>
                 {
                     //Here it means that the subset has been extracted
                     //-We need to add the subset
-                    subsets.AddIfUnique(_subSet.ToString());
+                    subsets.Add(_subSet.ToString());
 
                     //Reset the subset 
                     _subSet.Clear();
@@ -223,7 +223,7 @@ public class SetTreeBuilder<T>
                 //Check for nullls
                 if (item is not null)
                 {
-                    uniqueElements.AddIfUnique(item);
+                    uniqueElements.Add(item);
                 }
                 else
                 {

--- a/Sets Library/Sets Library/Utility/SetTreeUtility.cs
+++ b/Sets Library/Sets Library/Utility/SetTreeUtility.cs
@@ -66,7 +66,7 @@ public static class SetTreeUtility<T>
             if (representation.Length == 1)//Here it means there's only the opening brace without closing braces
                 representation += "{}";
             else
-                representation += currentTree.ExtractionSettings.RowTerminator + "{}"; //Add empty set with a row terminator
+                representation += currentTree.ExtractionSettings.RowTerminator + "{}"; //AddIfDuplicate empty set with a row terminator
             emptyAdded = true;
         }
 
@@ -86,7 +86,7 @@ public static class SetTreeUtility<T>
             if (representation.Length == 1) //If it's just a brace, then there are no root elements
                 representation += subsetTree;
             else
-                representation += currentTree.ExtractionSettings.RowTerminator + subsetTree; // Add subset with a row terminator
+                representation += currentTree.ExtractionSettings.RowTerminator + subsetTree; // AddIfDuplicate subset with a row terminator
         }
         //Attach the closing brace
         return representation + "}";

--- a/Sets Library/SetsLibrary.Tests/Collections/Element Collections/SortedElementsTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Collections/Element Collections/SortedElementsTests.cs
@@ -9,7 +9,7 @@ namespace SetsLibrary.Tests.Collections.Element_Collections
         public void Add_OneElement_ElementIsAdded()
         {
             var sortedElements = new SortedElements<int>();
-            sortedElements.Add(5);
+            sortedElements.AddIfDuplicate(5);
 
             Assert.Equal(1, sortedElements.Count);
             Assert.Equal(5, sortedElements[0]);
@@ -19,9 +19,9 @@ namespace SetsLibrary.Tests.Collections.Element_Collections
         public void Add_MultipleElements_ElementsAreSorted()
         {
             var sortedElements = new SortedElements<int>();
-            sortedElements.Add(3);
-            sortedElements.Add(1);
-            sortedElements.Add(2);
+            sortedElements.AddIfDuplicate(3);
+            sortedElements.AddIfDuplicate(1);
+            sortedElements.AddIfDuplicate(2);
 
             Assert.Equal(3, sortedElements.Count);
             Assert.Equal(1, sortedElements[0]);
@@ -33,16 +33,16 @@ namespace SetsLibrary.Tests.Collections.Element_Collections
         public void Add_NullElement_ThrowsArgumentNullException()
         {
             var sortedElements = new SortedElements<string>();
-            Assert.Throws<ArgumentNullException>(() => sortedElements.Add(null));
+            Assert.Throws<ArgumentNullException>(() => sortedElements.AddIfDuplicate(null));
         }//Add_NullElement_ThrowsArgumentNullException
 
         [Fact]
         public void Remove_ExistingElement_ElementIsRemoved()
         {
             var sortedElements = new SortedElements<int>();
-            sortedElements.Add(1);
-            sortedElements.Add(2);
-            sortedElements.Add(3);
+            sortedElements.AddIfDuplicate(1);
+            sortedElements.AddIfDuplicate(2);
+            sortedElements.AddIfDuplicate(3);
 
             sortedElements.Remove(2);
             Assert.Equal(2, sortedElements.Count);
@@ -54,8 +54,8 @@ namespace SetsLibrary.Tests.Collections.Element_Collections
         public void Remove_NonExistingElement_ReturnsFalse()
         {
             var sortedElements = new SortedElements<int>();
-            sortedElements.Add(1);
-            sortedElements.Add(2);
+            sortedElements.AddIfDuplicate(1);
+            sortedElements.AddIfDuplicate(2);
 
             bool result = sortedElements.Remove(3);
             Assert.False(result);
@@ -66,8 +66,8 @@ namespace SetsLibrary.Tests.Collections.Element_Collections
         public void Contains_ExistingElement_ReturnsTrue()
         {
             var sortedElements = new SortedElements<int>();
-            sortedElements.Add(1);
-            sortedElements.Add(2);
+            sortedElements.AddIfDuplicate(1);
+            sortedElements.AddIfDuplicate(2);
 
             Assert.True(sortedElements.Contains(1));
         }//Contains_ExistingElement_ReturnsTrue
@@ -76,8 +76,8 @@ namespace SetsLibrary.Tests.Collections.Element_Collections
         public void Contains_NonExistingElement_ReturnsFalse()
         {
             var sortedElements = new SortedElements<int>();
-            sortedElements.Add(1);
-            sortedElements.Add(2);
+            sortedElements.AddIfDuplicate(1);
+            sortedElements.AddIfDuplicate(2);
 
             Assert.False(sortedElements.Contains(3));
         }//Contains_NonExistingElement_ReturnsFalse
@@ -86,9 +86,9 @@ namespace SetsLibrary.Tests.Collections.Element_Collections
         public void IndexOf_ExistingElement_ReturnsCorrectIndex()
         {
             var sortedElements = new SortedElements<int>();
-            sortedElements.Add(1);
-            sortedElements.Add(2);
-            sortedElements.Add(3);
+            sortedElements.AddIfDuplicate(1);
+            sortedElements.AddIfDuplicate(2);
+            sortedElements.AddIfDuplicate(3);
 
             int index = sortedElements.IndexOf(2);
             Assert.Equal(1, index);
@@ -98,8 +98,8 @@ namespace SetsLibrary.Tests.Collections.Element_Collections
         public void IndexOf_NonExistingElement_ReturnsMinusOne()
         {
             var sortedElements = new SortedElements<int>();
-            sortedElements.Add(1);
-            sortedElements.Add(2);
+            sortedElements.AddIfDuplicate(1);
+            sortedElements.AddIfDuplicate(2);
 
             int index = sortedElements.IndexOf(3);
             Assert.Equal(-1, index);
@@ -109,8 +109,8 @@ namespace SetsLibrary.Tests.Collections.Element_Collections
         public void Clear_ElementsAreRemoved()
         {
             var sortedElements = new SortedElements<int>();
-            sortedElements.Add(1);
-            sortedElements.Add(2);
+            sortedElements.AddIfDuplicate(1);
+            sortedElements.AddIfDuplicate(2);
             sortedElements.Clear();
 
             Assert.Equal(0, sortedElements.Count);

--- a/Sets Library/SetsLibrary.Tests/Collections/Set Collection/SetCollectionTestsExcelSpreadSheedEmulator.cs
+++ b/Sets Library/SetsLibrary.Tests/Collections/Set Collection/SetCollectionTestsExcelSpreadSheedEmulator.cs
@@ -10,7 +10,7 @@ namespace SetsLibrary.Tests.Collections.Set_Collection
         {
             //Create an empty set
             collection = new SetCollection<int>();
-            //Add 16,384 empty sets. 
+            //AddIfDuplicate 16,384 empty sets. 
             var set = new MockSetStructure();
             for (int i = 0; i < 16384; i++)
                 collection.Add(set);

--- a/Sets Library/SetsLibrary.Tests/Extensions/SetTreeExtentiions.cs
+++ b/Sets Library/SetsLibrary.Tests/Extensions/SetTreeExtentiions.cs
@@ -168,6 +168,6 @@ public class SetTreeExtentiions
 
         //// Assert
         //Assert.NotEmpty(result);
-        //// Add assertions to check the complexity of the structured sets returned
+        //// AddIfDuplicate assertions to check the complexity of the structured sets returned
     }
 }

--- a/Sets Library/SetsLibrary.Tests/Extensions/SetTreeListConverter.cs
+++ b/Sets Library/SetsLibrary.Tests/Extensions/SetTreeListConverter.cs
@@ -265,7 +265,7 @@ public class SetTreeListConverter
         // Arrange
         var setTree = new SetTree<int>(config);
         var emptySubTree = new SetTree<int>(config);  // A subtree with no elements
-        setTree.AddElement(emptySubTree);  // Add it as a subset
+        setTree.AddElement(emptySubTree);  // AddIfDuplicate it as a subset
         var converter = new SetTreeListConverter<int>(setTree);
 
         // Act
@@ -285,9 +285,9 @@ public class SetTreeListConverter
         var internalCollection = new SortedCollection<int>();
         for (int i = 0; i < 100000; i++)  // Adding a large number of elements to internal collection
         {
-            internalCollection.Add(i);
+            internalCollection.AddIfDuplicate(i);
         }
-        setTree.AddRange(internalCollection);  // Add this large collection as an element
+        setTree.AddRange(internalCollection);  // AddIfDuplicate this large collection as an element
         var converter = new SetTreeListConverter<int>(setTree);
 
         // Act

--- a/Sets Library/SetsLibrary.Tests/Models/SetTree/SetTreeTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Models/SetTree/SetTreeTests.cs
@@ -560,7 +560,7 @@ namespace SetsLibrary.Tests.Models.SetTree
             var mainSet = new SetTree<int>(extractionSettings);
             var largeSubset = new SetTree<int>(extractionSettings);
 
-            // Add 1 million elements to a subset
+            // AddIfDuplicate 1 million elements to a subset
             largeSubset.AddRange(Enumerable.Range(0, 1000000));
 
             mainSet.AddElement(largeSubset);

--- a/Sets Library/SetsLibrary.Tests/Models/Sets/BaseSetWithTypedSetTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Models/Sets/BaseSetWithTypedSetTests.cs
@@ -171,7 +171,7 @@ namespace SetsLibrary.Tests.Models.Sets
             string expression = "{1,2,3}";
             var baseSet = new TypedSet<int>(expression, _extractionConfig);
 
-            // Add an element
+            // AddIfDuplicate an element
             baseSet.AddElement(4);
             Assert.Contains(4, baseSet.EnumerateRootElements());
             Assert.Equal(4, baseSet.Cardinality); // Should now have 4 elements
@@ -340,7 +340,7 @@ namespace SetsLibrary.Tests.Models.Sets
         {
             var baseSet = new TypedSet<int>(initialExpression, _extractionConfig);
 
-            // Add the element
+            // AddIfDuplicate the element
             baseSet.AddElement(elementToAdd);
 
             // Assert the resulting set matches the expected string representation

--- a/Sets Library/SetsLibrary.Tests/Models/Sets/StringLiteralTests.cs
+++ b/Sets Library/SetsLibrary.Tests/Models/Sets/StringLiteralTests.cs
@@ -55,7 +55,7 @@ namespace SetsLibrary.Tests.Models.Sets
             Assert.Equal("{0,1,2,3,4}", result);
         }
 
-        // Test for adding a new element to the set (assuming Add method exists)
+        // Test for adding a new element to the set (assuming AddIfDuplicate method exists)
         [Fact]
         public void Add_ShouldAddElementToSet()
         {

--- a/Sets Library/SetsLibrary.Tests/SetOperations/SetOperationsTests.cs
+++ b/Sets Library/SetsLibrary.Tests/SetOperations/SetOperationsTests.cs
@@ -783,13 +783,13 @@ namespace SetsLibrary.Tests
 
             // Assert Element-Set pairs (CartesianPairType.Element1Set1)
             var subsetB = CreateSet(new[] { 3 }); // Subset of setB
-            setB.AddElement(subsetB);  // Add subset to setB
+            setB.AddElement(subsetB);  // AddIfDuplicate subset to setB
             Assert.DoesNotContain(result, pair => pair.PairType == CartesianPairType.Element1Set1 && pair.Element1 == 1 && pair.Set1 == subsetB);
             Assert.DoesNotContain(result, pair => pair.PairType == CartesianPairType.Element1Set1 && pair.Element1 == 2 && pair.Set1 == subsetB);
 
             // Assert Set-Element pairs (CartesianPairType.Set1Element1)
             var subsetA = CreateSet(new[] { 1 }); // Subset of setA
-            setA.AddElement(subsetA);  // Add subset to setA
+            setA.AddElement(subsetA);  // AddIfDuplicate subset to setA
 
             result = setA.CartesianProduct(setB).ToList();
 
@@ -798,7 +798,7 @@ namespace SetsLibrary.Tests
 
             // Assert Set-Set pairs (CartesianPairType.Set1Set2)
             var subsetB2 = CreateSet(new[] { 4 }); // Another subset of setB
-            setB.AddElement(subsetB2);  // Add another subset to setB
+            setB.AddElement(subsetB2);  // AddIfDuplicate another subset to setB
             result = setA.CartesianProduct(setB).ToList();
             Assert.Contains(result, pair => pair.PairType == CartesianPairType.Set1Set2 && pair.Set1.SetStructuresEqual(subsetA) && pair.Set2.SetStructuresEqual( subsetB));
             Assert.Contains(result, pair => pair.PairType == CartesianPairType.Set1Set2 && pair.Set1.SetStructuresEqual(subsetA) && pair.Set2.SetStructuresEqual(subsetB2));
@@ -1001,11 +1001,11 @@ namespace SetsLibrary.Tests
             var setA = CreateSet(new[] { 1, 2, 3 }); // A set with elements
             var setB = CreateSet(new int[] { }); // Empty set B
 
-            // Add subsets to set A
+            // AddIfDuplicate subsets to set A
             var subsetA = CreateSet(new[] { 1, 2 });
             setA.AddElement(subsetA);
 
-            // Add a subset to set B (empty set has no root elements or subsets)
+            // AddIfDuplicate a subset to set B (empty set has no root elements or subsets)
             var subsetB = CreateSet(new[] { 4, 5 });
             setB.AddElement(subsetB);
 
@@ -1046,7 +1046,7 @@ namespace SetsLibrary.Tests
             var setB = CreateSet(setBElements); // Create set B from input
             var subset = CreateSet(subsetElements); // Create a subset
 
-            // Add the subset to set B (we assume subsets can be added to sets)
+            // AddIfDuplicate the subset to set B (we assume subsets can be added to sets)
             setB.AddElement(subset);
 
             // Act


### PR DESCRIPTION
Renamed the following `SetCollection<T>` methods:
- `Add` --> `AddIfDuplicate`
- `AddIfUnique` --> `Add`

The method `Add` is now the default add method that doesn't add any duplicates because of the nature of the framework.